### PR TITLE
feat(model-api-gen): allow generating concept into ts children accessors

### DIFF
--- a/docs/global/modules/core/pages/reference/component-model-api-gen-gradle.adoc
+++ b/docs/global/modules/core/pages/reference/component-model-api-gen-gradle.adoc
@@ -104,7 +104,15 @@ Inside of the `metamodel` block the following settings can be configured.
 |`includeTypescriptBarrels`
 |Boolean
 |Add barrelling to the generated index file for convenience.
-Only enable when you are completely sure there are no naming conflicts among the concepts of all generated languages.
+ Only enable when you are completely sure there are no naming conflicts among the concepts of all generated languages.
+
+|`includeTypescriptConceptForChildAccessors`
+|Boolean
+|Whether to add base concept to generated child accessors.
+ It simplifies the process of creating new child nodes by requiring the concept for a new node to be specified only
+ if a sub-concept is needed.
+
+ Note: Enable this feature only if you are using `ts-model-api` version 8.8.0 or higher.
 
 |`registrationHelperName`
 |String

--- a/model-api-gen-gradle-test/metamodel-export/build.gradle.kts
+++ b/model-api-gen-gradle-test/metamodel-export/build.gradle.kts
@@ -31,6 +31,7 @@ metamodel {
     }
     registrationHelperName = "org.modelix.apigen.test.ApigenTestLanguages"
     conceptPropertiesInterfaceName = "org.modelix.apigen.test.IMetaConceptProperties"
+    includeTypescriptConceptForChildAccessors = true
 }
 
 dependencies {

--- a/model-api-gen-gradle-test/typescript-generation/package-lock.json
+++ b/model-api-gen-gradle-test/typescript-generation/package-lock.json
@@ -1130,7 +1130,7 @@
     "node_modules/@modelix/model-client": {
       "version": "8.2.1-1-g563e21c.dirty-SNAPSHOT",
       "resolved": "file:../../model-client/build/npmDevPackage/model-client.tgz",
-      "integrity": "sha512-1Qabw/BnJnvACjJx54ucPdYxepL9Qox3tp2QjzbSTjQfhjra9tA0kI34nZOdX8rD03NslmWxp32pmD+xSAvt8g==",
+      "integrity": "sha512-L5xO9D2wsI2hrjcJw3F2sUXvG2EksXEXJ5u/w5piLcFLwLxGuW3V+NmT0/0QvSNKk7dl+XFHB3dmO3UKoRrOaQ==",
       "dependencies": {
         "@aws-crypto/sha256-js": "^5.0.0",
         "@js-joda/core": "3.2.0",
@@ -5587,7 +5587,7 @@
     },
     "@modelix/model-client": {
       "version": "file:../../model-client/build/npmDevPackage/model-client.tgz",
-      "integrity": "sha512-1Qabw/BnJnvACjJx54ucPdYxepL9Qox3tp2QjzbSTjQfhjra9tA0kI34nZOdX8rD03NslmWxp32pmD+xSAvt8g==",
+      "integrity": "sha512-L5xO9D2wsI2hrjcJw3F2sUXvG2EksXEXJ5u/w5piLcFLwLxGuW3V+NmT0/0QvSNKk7dl+XFHB3dmO3UKoRrOaQ==",
       "requires": {
         "@aws-crypto/sha256-js": "^5.0.0",
         "@js-joda/core": "3.2.0",

--- a/model-api-gen-gradle-test/typescript-generation/src/ChildrenAccessor.test.ts
+++ b/model-api-gen-gradle-test/typescript-generation/src/ChildrenAccessor.test.ts
@@ -28,6 +28,15 @@ const NODE_DATA_WITH_SINGLE_CHILD_ACCESSOR = {
   },
 };
 
+test("new element can be added to SingleChildAccessor without providing the base concept", () => {
+  const { typedNode } = useFakeNode<BaseCommentAttribute>(
+    "withSingleChildAccessor",
+    NODE_DATA_WITH_SINGLE_CHILD_ACCESSOR
+  );
+  const childNode = typedNode.commentedNode.setNew();
+  expect(isOfConcept_BaseConcept(childNode)).toBeTruthy();
+});
+
 test("new element can be added to SingleChildAccessor when provided the correct base concept", () => {
   const { typedNode } = useFakeNode<BaseCommentAttribute>(
     "withSingleChildAccessor",

--- a/model-api-gen-gradle-test/vue-integration/package-lock.json
+++ b/model-api-gen-gradle-test/vue-integration/package-lock.json
@@ -1065,7 +1065,7 @@
     "node_modules/@modelix/model-client": {
       "version": "8.2.1-1-g563e21c.dirty-SNAPSHOT",
       "resolved": "file:../../model-client/build/npmDevPackage/model-client.tgz",
-      "integrity": "sha512-1Qabw/BnJnvACjJx54ucPdYxepL9Qox3tp2QjzbSTjQfhjra9tA0kI34nZOdX8rD03NslmWxp32pmD+xSAvt8g==",
+      "integrity": "sha512-L5xO9D2wsI2hrjcJw3F2sUXvG2EksXEXJ5u/w5piLcFLwLxGuW3V+NmT0/0QvSNKk7dl+XFHB3dmO3UKoRrOaQ==",
       "dependencies": {
         "@aws-crypto/sha256-js": "^5.0.0",
         "@js-joda/core": "3.2.0",
@@ -3998,7 +3998,7 @@
     "node_modules/typescript-generation": {
       "version": "0.0.0",
       "resolved": "file:../typescript-generation/build/typescript-generation-0.0.0.tgz",
-      "integrity": "sha512-LJC8xPZUvIofKV+uQF4AEId2N782tniHDg7cZsbanSsepcGgiszxR6Wc8+GGMukfl8fmfQawyNBBjaxKFlhE9g==",
+      "integrity": "sha512-O8HMTrvbTOr/vRkRH6uWD0IjvsMLO+4ed+hPaYpZsyW7Us1dfAczg8q7hSXp3tRNSYR7pItDgfKIzPZ3Nj/udA==",
       "license": "Apache 2.0",
       "dependencies": {
         "@modelix/model-client": "file:../../model-client/build/npmDevPackage/model-client.tgz",

--- a/model-api-gen-gradle/src/main/kotlin/org/modelix/metamodel/gradle/GenerateMetaModelSources.kt
+++ b/model-api-gen-gradle/src/main/kotlin/org/modelix/metamodel/gradle/GenerateMetaModelSources.kt
@@ -43,6 +43,9 @@ abstract class GenerateMetaModelSources @Inject constructor(of: ObjectFactory) :
     val includeTypescriptBarrels: Property<Boolean> = of.property(Boolean::class.java)
 
     @get:Input
+    val includeTypescriptConceptForChildAccessors: Property<Boolean> = of.property(Boolean::class.java)
+
+    @get:Input
     val includedNamespaces: ListProperty<String> = of.listProperty(String::class.java)
 
     @get:Input
@@ -117,7 +120,12 @@ abstract class GenerateMetaModelSources @Inject constructor(of: ObjectFactory) :
 
         val typescriptOutputDir = this.typescriptOutputDir.orNull?.asFile
         if (typescriptOutputDir != null) {
-            val tsGenerator = TypescriptMMGenerator(typescriptOutputDir.toPath(), nameConfig.get(), includeTypescriptBarrels.get())
+            val tsGenerator = TypescriptMMGenerator(
+                outputDir = typescriptOutputDir.toPath(),
+                nameConfig = nameConfig.get(),
+                includeBarrels = includeTypescriptBarrels.get(),
+                includeConceptForChildAccessors = includeTypescriptConceptForChildAccessors.get(),
+            )
             tsGenerator.generate(processedLanguages)
         }
     }

--- a/model-api-gen-gradle/src/main/kotlin/org/modelix/metamodel/gradle/MetaModelGradlePlugin.kt
+++ b/model-api-gen-gradle/src/main/kotlin/org/modelix/metamodel/gradle/MetaModelGradlePlugin.kt
@@ -77,6 +77,7 @@ class MetaModelGradlePlugin @Inject constructor(val project: Project) : Plugin<P
                 settings.modelqlKotlinDir?.let { task.modelqlKotlinOutputDir.set(it) }
                 settings.typescriptDir?.let { task.typescriptOutputDir.set(it) }
                 task.includeTypescriptBarrels.set(settings.includeTypescriptBarrels)
+                task.includeTypescriptConceptForChildAccessors.set(settings.includeTypescriptConceptForChildAccessors)
                 task.includedNamespaces.addAll(settings.includedLanguageNamespaces)
                 task.includedLanguages.addAll(settings.includedLanguages)
                 task.includedConcepts.addAll(settings.includedConcepts)

--- a/model-api-gen-gradle/src/main/kotlin/org/modelix/metamodel/gradle/MetaModelGradleSettings.kt
+++ b/model-api-gen-gradle/src/main/kotlin/org/modelix/metamodel/gradle/MetaModelGradleSettings.kt
@@ -30,6 +30,7 @@ open class MetaModelGradleSettings {
         }
     var typescriptDir: File? = null
     var includeTypescriptBarrels: Boolean = false
+    var includeTypescriptConceptForChildAccessors: Boolean = false
     var registrationHelperName: String? = null
     var conceptPropertiesInterfaceName: String? = null
     val taskDependencies: MutableList<Any> = ArrayList()

--- a/model-api-gen/src/main/kotlin/org/modelix/metamodel/generator/TypescriptMMGenerator.kt
+++ b/model-api-gen/src/main/kotlin/org/modelix/metamodel/generator/TypescriptMMGenerator.kt
@@ -8,7 +8,12 @@ import java.nio.file.Files
 import java.nio.file.Path
 import kotlin.io.path.writeText
 
-class TypescriptMMGenerator(val outputDir: Path, val nameConfig: NameConfig = NameConfig(), private val includeTsBarrels: Boolean = false) {
+class TypescriptMMGenerator(
+    val outputDir: Path,
+    val nameConfig: NameConfig = NameConfig(),
+    private val includeBarrels: Boolean = false,
+    private val includeConceptForChildAccessors: Boolean = false,
+) {
 
     private fun LanguageData.packageDir(): Path {
         val packageName = name
@@ -68,7 +73,7 @@ class TypescriptMMGenerator(val outputDir: Path, val nameConfig: NameConfig = Na
             """
             }}
             }
-            ${if (!includeTsBarrels) {
+            ${if (!includeBarrels) {
                 ""
             } else {
                 languages.getLanguages().joinToString("\n") {
@@ -196,7 +201,7 @@ class TypescriptMMGenerator(val outputDir: Path, val nameConfig: NameConfig = Na
                     val typeRef = feature.type.resolved
                     val languagePrefix = typeRef.languagePrefix(concept.language)
                     """
-                        public ${feature.generatedName}: $accessorClassName<$languagePrefix${typeRef.nodeWrapperInterfaceName()}> = new $accessorClassName(this._node, "${feature.originalName}")
+                        public ${feature.generatedName}: $accessorClassName<$languagePrefix${typeRef.nodeWrapperInterfaceName()}> = new $accessorClassName(this._node, "${feature.originalName}"${if (includeConceptForChildAccessors) ", $languagePrefix${typeRef.conceptWrapperInterfaceName()}" else ""})
                     """
                 }
                 else -> ""

--- a/vue-model-api/package-lock.json
+++ b/vue-model-api/package-lock.json
@@ -1281,7 +1281,7 @@
     "node_modules/@modelix/model-client": {
       "version": "8.2.1-1-g563e21c.dirty-SNAPSHOT",
       "resolved": "file:../model-client/build/npmDevPackage/model-client.tgz",
-      "integrity": "sha512-1Qabw/BnJnvACjJx54ucPdYxepL9Qox3tp2QjzbSTjQfhjra9tA0kI34nZOdX8rD03NslmWxp32pmD+xSAvt8g==",
+      "integrity": "sha512-L5xO9D2wsI2hrjcJw3F2sUXvG2EksXEXJ5u/w5piLcFLwLxGuW3V+NmT0/0QvSNKk7dl+XFHB3dmO3UKoRrOaQ==",
       "dependencies": {
         "@aws-crypto/sha256-js": "^5.0.0",
         "@js-joda/core": "3.2.0",


### PR DESCRIPTION
This PR is a continuation of https://github.com/modelix/modelix.core/pull/837

Now being able to create a correctly typed child is pretty nice. But it is still annoying having to provide the concept even though we already know the return type. At least if you don't want to explicitly provide a sub concept. 

This new feature improves the code generation so that the expected base concept is passed to the initialization of the Child Accessors classes. This way we can fall back to this base concept.

```typescipt
// before (but after https://github.com/modelix/modelix.core/pull/837)
const typedNode: BasePlaceholder = foo();
const childNode: IPlaceholderContent = typedNode.content.setNew(C_IPlaceholderContent); 
expect(isOfConcept_IPlaceholderContent(childNode)).toBeTruthy(); // <---- succeeds

// after after
const typedNode: BasePlaceholder = foo();
const childNode: IPlaceholderContent = typedNode.content.setNew(); 
expect(isOfConcept_IPlaceholderContent(childNode)).toBeTruthy(); // <---- succeeds
```

## To be verified by reviewers

* [ ] Relevant public API members have been documented
* [ ] Documentation related to this PR is complete
  * [ ] Boundary conditions are documented
  * [ ] Exceptions are documented
  * [ ] Nullability is documented if used
* [ ] Touched existing code has been extended with documentation if missing
* [ ] Code is readable
* [ ] New features and fixed bugs are covered by tests
