### PR TITLE
feat(ts-model-api): add verification to sub concepts when adding child

### DIFF
--- a/model-api-gen-gradle-test/typescript-generation/src/ChildrenAccessor.test.ts
+++ b/model-api-gen-gradle-test/typescript-generation/src/ChildrenAccessor.test.ts
@@ -8,6 +8,7 @@ import {
   BaseCommentAttribute,
   C_BaseCommentAttribute,
   C_BaseConcept,
+  C_InterfacePart,
   C_TypeAnnotated,
   isOfConcept_BaseConcept,
   isOfConcept_TypeAnnotated,
@@ -54,4 +55,12 @@ test("new element can be added to SingleChildAccessor when provided a sub concep
   const childNode = typedNode.commentedNode.setNew(C_TypeAnnotated);
   expect(isOfConcept_TypeAnnotated(childNode)).toBeTruthy();
   expect(isOfConcept_BaseConcept(childNode)).toBeTruthy();
+});
+
+test("new element cannot be added to SingleChildAccessor when provided sub concept does not extend base concept", () => {
+  const { typedNode } = useFakeNode<BaseCommentAttribute>(
+    "withSingleChildAccessor",
+    NODE_DATA_WITH_SINGLE_CHILD_ACCESSOR
+  );
+  expect(() => typedNode.commentedNode.setNew(C_InterfacePart)).toThrow();
 });


### PR DESCRIPTION
This PR is a continuation of https://github.com/modelix/modelix.core/pull/837 and https://github.com/drik98/modelix.core/pull/2

Prior to this PR when creating a new child in a typescript child accessor you could provide any concept even if it was not actually a sub concept of the base concept. This PR adds validation and throws a runtime exception when the provided concept is wrong.

```typescipt
// before
const typedNode: BasePlaceholder = foo();
const childNode: IPlaceholderContent = typedNode.content.setNew(C_InterfacePart); // Creates a node of concept C_InterfacePart even though it is not applicable to type IPlaceholderContent

// after
const typedNode: BasePlaceholder = foo();
const childNode: IPlaceholderContent = typedNode.content.setNew(C_InterfacePart); // throws error
```

## To be verified by reviewers

* [ ] Relevant public API members have been documented
* [ ] Documentation related to this PR is complete
  * [ ] Boundary conditions are documented
  * [ ] Exceptions are documented
  * [ ] Nullability is documented if used
* [ ] Touched existing code has been extended with documentation if missing
* [ ] Code is readable
* [ ] New features and fixed bugs are covered by tests
